### PR TITLE
Fix sendException method not accept throwable

### DIFF
--- a/src/ZfBugsnag/Service/BugsnagService.php
+++ b/src/ZfBugsnag/Service/BugsnagService.php
@@ -117,17 +117,17 @@ class BugsnagService
 
     /**
      * sendException
-     * Send the Exception to the Bugsnag Servers
+     * Send the non-fatal/handled throwable to the Bugsnag Servers
      *
-     * @param object \Exception $e
+     * @param object \Throwable $throwable the throwable to notify Bugsnag about
      */
-    public function sendException(\Exception $e)
+    public function sendException($throwable)
     {
         // Check if we have to send the Exception
         if($this->options->getEnabled())
         {
             // Send it
-            $this->bugsnag->notifyException($e);
+            $this->bugsnag->notifyException($throwable);
         }
     }
 }


### PR DESCRIPTION
The notifyException method of bugsnag now accepts `Throwable`
(https://github.com/bugsnag/bugsnag-php/blob/v2.9.2/src/Bugsnag/Client.php#L515-L532), which allows to be compatible with PHP7 Error.

I am not typed the function parameter to remain compatible with PHP5.
A control of the parameter is performed by the `notifyException` function of bugsnag.